### PR TITLE
[Fix] #9 여행 플랜 장소 수정

### DIFF
--- a/src/main/java/com/pravell/place/application/DeletePlaceService.java
+++ b/src/main/java/com/pravell/place/application/DeletePlaceService.java
@@ -4,7 +4,7 @@ import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.place.domain.model.PinPlace;
 import com.pravell.place.domain.model.PlanMember;
 import com.pravell.place.domain.repository.PinPlaceRepository;
-import com.pravell.place.domain.service.PlanAuthorizationService;
+import com.pravell.place.domain.service.PlaceAuthorizationService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeletePlaceService {
 
-    private final PlanAuthorizationService planAuthorizationService;
+    private final PlaceAuthorizationService placeAuthorizationService;
     private final PinPlaceRepository pinPlaceRepository;
 
     @Transactional
@@ -27,7 +27,7 @@ public class DeletePlaceService {
     }
 
     private void validatePlaceDeletionPermission(List<PlanMember> planMembers, UUID id, UUID planId, Long placeId) {
-        if (!planAuthorizationService.hasUpdatePermission(id, planMembers)) {
+        if (!placeAuthorizationService.hasUpdatePermission(id, planMembers)) {
             log.info("{} 유저는 {} 플랜의 {} 장소를 삭제 할 권한이 없습니다.", id, planId, placeId);
             throw new AccessDeniedException("해당 장소를 삭제 할 권한이 없습니다.");
         }

--- a/src/main/java/com/pravell/place/application/FindPlaceService.java
+++ b/src/main/java/com/pravell/place/application/FindPlaceService.java
@@ -31,21 +31,8 @@ public class FindPlaceService {
     public List<FindPlanPlacesResponse> findAll(UUID userId, UUID planId, List<PlanMember> planMembers,
                                                 boolean isPlanPublic) {
         validateAccessToPlan(userId, planMembers, planId, isPlanPublic);
-
         List<PinPlace> pinPlaces = pinPlaceRepository.findAllByPlanId(planId);
-
-        return pinPlaces.stream().map(pp -> {
-            return FindPlanPlacesResponse.builder()
-                    .id(pp.getId())
-                    .nickname(pp.getNickname())
-                    .title(pp.getTitle())
-                    .mapx(pp.getMapx())
-                    .mapy(pp.getMapy())
-                    .lat(pp.getLatitude())
-                    .lng(pp.getLongitude())
-                    .pinColor(pp.getPinColor())
-                    .build();
-        }).toList();
+        return buildFindPlanPlacesResponses(pinPlaces);
     }
 
     @Transactional(readOnly = true)
@@ -56,6 +43,25 @@ public class FindPlaceService {
         List<String> hours = parseHours(place);
 
         return buildPlaceResponse(place, hours);
+    }
+
+    private List<FindPlanPlacesResponse> buildFindPlanPlacesResponses(List<PinPlace> pinPlaces) {
+        return pinPlaces.stream().map(pp -> {
+            List<String> hours = parseHours(pp);
+            return FindPlanPlacesResponse.builder()
+                    .id(pp.getId())
+                    .nickname(pp.getNickname())
+                    .title(pp.getTitle())
+                    .mapx(pp.getMapx())
+                    .mapy(pp.getMapy())
+                    .lat(pp.getLatitude())
+                    .lng(pp.getLongitude())
+                    .pinColor(pp.getPinColor())
+                    .address(pp.getAddress())
+                    .roadAddress(pp.getRoadAddress())
+                    .hours(hours)
+                    .build();
+        }).toList();
     }
 
     private void validateAccessToPlan(UUID userId, List<PlanMember> planMembers, UUID planId, boolean isPlanPublic) {

--- a/src/main/java/com/pravell/place/application/SavePlaceService.java
+++ b/src/main/java/com/pravell/place/application/SavePlaceService.java
@@ -7,7 +7,7 @@ import com.pravell.place.application.dto.request.SavePlaceApplicationRequest;
 import com.pravell.place.domain.model.PinPlace;
 import com.pravell.place.domain.model.PlanMember;
 import com.pravell.place.domain.repository.PinPlaceRepository;
-import com.pravell.place.domain.service.PlanAuthorizationService;
+import com.pravell.place.domain.service.PlaceAuthorizationService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -24,7 +24,7 @@ public class SavePlaceService {
 
     private final PinPlaceRepository pinPlaceRepository;
     private final ObjectMapper objectMapper;
-    private final PlanAuthorizationService planAuthorizationService;
+    private final PlaceAuthorizationService placeAuthorizationService;
 
     @Transactional
     public Long save(UUID id, SavePlaceApplicationRequest request, List<PlanMember> planMembers) {
@@ -38,7 +38,7 @@ public class SavePlaceService {
     }
 
     private void validatePlaceSavePermission(UUID id, SavePlaceApplicationRequest request, List<PlanMember> planMembers) {
-        if (!planAuthorizationService.hasUpdatePermission(id, planMembers)){
+        if (!placeAuthorizationService.hasUpdatePermission(id, planMembers)){
             log.info("{} 유저는 {} 플랜에 장소를 저장 할 권한이 없습니다.", id, request.getPlanId());
             throw new AccessDeniedException("해당 플랜에 장소를 저장 할 권한이 없습니다.");
         }

--- a/src/main/java/com/pravell/place/application/UpdatePlaceService.java
+++ b/src/main/java/com/pravell/place/application/UpdatePlaceService.java
@@ -7,7 +7,7 @@ import com.pravell.place.application.dto.request.UpdatePlaceApplicationRequest;
 import com.pravell.place.application.dto.response.PlaceResponse;
 import com.pravell.place.domain.model.PinPlace;
 import com.pravell.place.domain.model.PlanMember;
-import com.pravell.place.domain.service.PlanAuthorizationService;
+import com.pravell.place.domain.service.PlaceAuthorizationService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +24,7 @@ import org.springframework.util.StringUtils;
 public class UpdatePlaceService {
 
     private final ObjectMapper objectMapper;
-    private final PlanAuthorizationService planAuthorizationService;
+    private final PlaceAuthorizationService placeAuthorizationService;
 
     @Transactional
     public PlaceResponse update(PinPlace place, List<PlanMember> planMembers, UpdatePlaceApplicationRequest request,
@@ -39,7 +39,7 @@ public class UpdatePlaceService {
     }
 
     private void validateUpdatePermission(PinPlace place, List<PlanMember> planMembers, UUID id) {
-        if (!planAuthorizationService.hasUpdatePermission(id, planMembers)){
+        if (!placeAuthorizationService.hasUpdatePermission(id, planMembers)){
             log.info("{} 유저는 {} 플랜을 수정 할 권한이 없습니다.", id, place.getPlanId());
             throw new AccessDeniedException("해당 장소를 수정 할 권한이 없습니다.");
         }

--- a/src/main/java/com/pravell/place/application/dto/response/FindPlanPlacesResponse.java
+++ b/src/main/java/com/pravell/place/application/dto/response/FindPlanPlacesResponse.java
@@ -1,6 +1,7 @@
 package com.pravell.place.application.dto.response;
 
 import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,5 +17,8 @@ public class FindPlanPlacesResponse {
     private BigDecimal lat;
     private BigDecimal lng;
     private String pinColor;
+    private String address;
+    private String roadAddress;
+    private List<String> hours;
 
 }

--- a/src/main/java/com/pravell/place/domain/service/PlaceAuthorizationService.java
+++ b/src/main/java/com/pravell/place/domain/service/PlaceAuthorizationService.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PlanAuthorizationService {
+public class PlaceAuthorizationService {
 
     public boolean hasUpdatePermission(UUID userId, List<PlanMember> planMembers) {
         return planMembers.stream()

--- a/src/main/java/com/pravell/plan/application/CreateInviteCodeService.java
+++ b/src/main/java/com/pravell/plan/application/CreateInviteCodeService.java
@@ -3,9 +3,9 @@ package com.pravell.plan.application;
 import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanInviteCode;
-import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
 import com.pravell.plan.domain.repository.PlanInviteCodeRepository;
+import com.pravell.plan.domain.service.PlanAuthorizationService;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateInviteCodeService {
 
     private final PlanInviteCodeRepository planInviteCodeRepository;
+    private final PlanAuthorizationService planAuthorizationService;
 
     @Value("${invite-code.characters}")
     private String CHARACTERS;
@@ -49,11 +50,7 @@ public class CreateInviteCodeService {
     }
 
     private void validateMemberOrOwnerForInviteCode(List<PlanUsers> planUsers, UUID userId) {
-        boolean isMember = planUsers.stream().anyMatch(pu -> pu.getUserId().equals(userId) &&
-                (pu.getPlanUserStatus().equals(PlanUserStatus.OWNER) || pu.getPlanUserStatus()
-                        .equals(PlanUserStatus.MEMBER)));
-
-        if (!isMember){
+        if (!planAuthorizationService.isOwnerOrMember(userId, planUsers)){
             throw new AccessDeniedException("해당 플랜의 초대코드를 생성 할 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/pravell/plan/application/DeletePlanService.java
+++ b/src/main/java/com/pravell/plan/application/DeletePlanService.java
@@ -2,8 +2,8 @@ package com.pravell.plan.application;
 
 import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.domain.model.Plan;
-import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
+import com.pravell.plan.domain.service.PlanAuthorizationService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeletePlanService {
 
+    private final PlanAuthorizationService planAuthorizationService;
+
     @Transactional
     public void deletePlan(Plan plan, UUID userId, List<PlanUsers> planUsers) {
         log.info("{} 유저가 {} 플랜 삭제.", userId, plan.getId());
@@ -24,10 +26,7 @@ public class DeletePlanService {
     }
 
     private void validateOwnerPermission(UUID id, List<PlanUsers> planUsers) {
-        boolean isOwner = planUsers.stream()
-                .anyMatch(pu -> pu.getUserId().equals(id) && pu.getPlanUserStatus().equals(PlanUserStatus.OWNER));
-
-        if (!isOwner) {
+        if (!planAuthorizationService.isOwner(id, planUsers)) {
             throw new AccessDeniedException("해당 리소스를 삭제 할 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/pravell/plan/application/KickUserService.java
+++ b/src/main/java/com/pravell/plan/application/KickUserService.java
@@ -4,6 +4,7 @@ import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.application.dto.request.KickUsersFromPlanApplicationRequest;
 import com.pravell.plan.domain.exception.PlanNotFoundException;
 import com.pravell.plan.domain.model.PlanUsers;
+import com.pravell.plan.domain.service.PlanAuthorizationService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -18,13 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class KickUserService {
 
+    private final PlanAuthorizationService planAuthorizationService;
+
     @Transactional
     public void kickUsers(UUID id, List<PlanUsers> planUsers, KickUsersFromPlanApplicationRequest request) {
+        validate(planUsers, id);
+
         Map<UUID, PlanUsers> planUsersMap = planUsers.stream()
                 .collect(Collectors.toMap(PlanUsers::getUserId, pu -> pu));
 
-        for (UUID kickUserId : request.getDeleteUsers()){
-            if (id.equals(kickUserId)){
+        for (UUID kickUserId : request.getDeleteUsers()) {
+            if (id.equals(kickUserId)) {
                 throw new IllegalArgumentException("본인은 삭제할 수 없습니다.");
             }
 
@@ -33,8 +38,7 @@ public class KickUserService {
                 throw new PlanNotFoundException("해당 플랜에 유저가 존재하지 않습니다.");
             }
 
-
-            switch(user.getPlanUserStatus()) {
+            switch (user.getPlanUserStatus()) {
                 case MEMBER -> {
                     log.info("{} 유저가 {} 유저를 {} 플랜에서 퇴출시켰습니다.", id, kickUserId, user.getPlanId());
                     user.updateToKicked();
@@ -42,6 +46,12 @@ public class KickUserService {
                 case OWNER -> throw new AccessDeniedException("플랜을 소유한 유저는 퇴출시킬 수 없습니다.");
                 default -> throw new PlanNotFoundException("해당 플랜에 유저가 존재하지 않습니다.");
             }
+        }
+    }
+
+    private void validate(List<PlanUsers> planUsers, UUID userId) {
+        if (!planAuthorizationService.isOwner(userId, planUsers)){
+            throw new AccessDeniedException("해당 리소스에 접근 할 권한이 없습니다.");
         }
     }
 

--- a/src/main/java/com/pravell/plan/application/PlanFacade.java
+++ b/src/main/java/com/pravell/plan/application/PlanFacade.java
@@ -89,6 +89,8 @@ public class PlanFacade {
                 .ownerId(ownerId)
                 .ownerNickname(ownerAndMembers.getFirst())
                 .member(ownerAndMembers.getSecond())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
                 .build();
     }
 

--- a/src/main/java/com/pravell/plan/application/PlanFacade.java
+++ b/src/main/java/com/pravell/plan/application/PlanFacade.java
@@ -10,7 +10,6 @@ import com.pravell.plan.domain.model.Member;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
-import com.pravell.plan.presentation.request.UpdatePlanRequest;
 import com.pravell.user.application.UserService;
 import com.pravell.user.application.dto.UserMemberDTO;
 import java.util.ArrayList;
@@ -41,6 +40,8 @@ public class PlanFacade {
                 .createdAt(planCreatedEvent.getCreatedAt())
                 .isPublic(planCreatedEvent.getPlan().getIsPublic())
                 .name(planCreatedEvent.getPlan().getName())
+                .startDate(planCreatedEvent.getPlan().getStartDate())
+                .endDate(planCreatedEvent.getPlan().getEndDate())
                 .build();
     }
 

--- a/src/main/java/com/pravell/plan/application/PlanFacade.java
+++ b/src/main/java/com/pravell/plan/application/PlanFacade.java
@@ -121,12 +121,13 @@ public class PlanFacade {
 
         updatePlanService.update(plan, userId, planUsers, request);
 
-        Plan afterPlan = planService.findPlan(planId);
         return CreatePlanResponse.builder()
-                .planId(afterPlan.getId())
-                .name(afterPlan.getName())
-                .isPublic(afterPlan.getIsPublic())
-                .createdAt(afterPlan.getCreatedAt())
+                .planId(plan.getId())
+                .name(plan.getName())
+                .isPublic(plan.getIsPublic())
+                .createdAt(plan.getCreatedAt())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
                 .build();
     }
 

--- a/src/main/java/com/pravell/plan/application/PlanMemberFacade.java
+++ b/src/main/java/com/pravell/plan/application/PlanMemberFacade.java
@@ -1,13 +1,11 @@
 package com.pravell.plan.application;
 
-import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.application.dto.request.KickUsersFromPlanApplicationRequest;
 import com.pravell.plan.application.dto.request.WithdrawFromPlansApplicationRequest;
 import com.pravell.plan.application.dto.response.InviteCodeResponse;
 import com.pravell.plan.application.dto.response.PlanJoinUserResponse;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanInviteCode;
-import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
 import com.pravell.user.application.UserService;
 import java.util.List;
@@ -57,13 +55,6 @@ public class PlanMemberFacade {
 
         planService.findPlan(planId);
         List<PlanUsers> planUsers = planService.findPlanUsers(planId);
-
-        boolean isOwner = planUsers.stream()
-                .anyMatch(pu -> pu.getUserId().equals(id) && pu.getPlanUserStatus().equals(PlanUserStatus.OWNER));
-
-        if (!isOwner) {
-            throw new AccessDeniedException("해당 리소스에 접근 할 권한이 없습니다.");
-        }
 
         kickUserService.kickUsers(id, planUsers, request);
     }

--- a/src/main/java/com/pravell/plan/application/PlanService.java
+++ b/src/main/java/com/pravell/plan/application/PlanService.java
@@ -54,13 +54,23 @@ public class PlanService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isPlanPublic(UUID planId){
+    public boolean isPlanPublic(UUID planId) {
         Optional<Plan> plan = planRepository.findById(planId);
         if (plan.isEmpty() || plan.get().getIsDeleted() == true) {
             throw new PlanNotFoundException("플랜을 찾을 수 없습니다.");
         }
 
         return plan.get().getIsPublic();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlanUsers> findMemberOrOwnerPlanByUsers(UUID id) {
+        List<PlanUsers> planUsers = planUsersRepository.findAllByUserId(id);
+
+        return planUsers.stream()
+                .filter(pu -> pu.getPlanUserStatus().equals(PlanUserStatus.MEMBER) ||
+                        pu.getPlanUserStatus().equals(PlanUserStatus.OWNER))
+                .toList();
     }
 
 }

--- a/src/main/java/com/pravell/plan/application/UpdatePlanService.java
+++ b/src/main/java/com/pravell/plan/application/UpdatePlanService.java
@@ -3,8 +3,8 @@ package com.pravell.plan.application;
 import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.application.dto.request.UpdatePlanApplicationRequest;
 import com.pravell.plan.domain.model.Plan;
-import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
+import com.pravell.plan.domain.service.PlanAuthorizationService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @RequiredArgsConstructor
 public class UpdatePlanService {
+
+    private final PlanAuthorizationService planAuthorizationService;
 
     @Transactional
     public void update(Plan plan, UUID userId, List<PlanUsers> planUsers,
@@ -42,11 +44,8 @@ public class UpdatePlanService {
         }
     }
 
-    private static void validateUpdatePermission(UUID userId, List<PlanUsers> planUsers) {
-        boolean isOwner = planUsers.stream()
-                .anyMatch(pu -> pu.getUserId().equals(userId) && pu.getPlanUserStatus().equals(PlanUserStatus.OWNER));
-
-        if (!isOwner) {
+    private void validateUpdatePermission(UUID userId, List<PlanUsers> planUsers) {
+        if (!planAuthorizationService.isOwner(userId, planUsers)){
             throw new AccessDeniedException("해당 리소스를 수정 할 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/pravell/plan/application/UpdatePlanService.java
+++ b/src/main/java/com/pravell/plan/application/UpdatePlanService.java
@@ -31,6 +31,15 @@ public class UpdatePlanService {
         if (request.getName() != null) {
             plan.updateName(request.getName());
         }
+        if (request.getStartDate() != null && request.getEndDate() != null) {
+            plan.updateDate(request.getStartDate(), request.getEndDate());
+        }
+        if (request.getStartDate() != null) {
+            plan.updateStartDate(request.getStartDate());
+        }
+        if (request.getEndDate() != null) {
+            plan.updateEndDate(request.getEndDate());
+        }
     }
 
     private static void validateUpdatePermission(UUID userId, List<PlanUsers> planUsers) {

--- a/src/main/java/com/pravell/plan/application/dto/request/CreatePlanApplicationRequest.java
+++ b/src/main/java/com/pravell/plan/application/dto/request/CreatePlanApplicationRequest.java
@@ -1,5 +1,6 @@
 package com.pravell.plan.application.dto.request;
 
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,5 +10,7 @@ public class CreatePlanApplicationRequest {
 
     private String name;
     private Boolean isPublic;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
 }

--- a/src/main/java/com/pravell/plan/application/dto/request/UpdatePlanApplicationRequest.java
+++ b/src/main/java/com/pravell/plan/application/dto/request/UpdatePlanApplicationRequest.java
@@ -1,5 +1,6 @@
 package com.pravell.plan.application.dto.request;
 
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,5 +10,7 @@ public class UpdatePlanApplicationRequest {
 
     private String name;
     private Boolean isPublic;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
 }

--- a/src/main/java/com/pravell/plan/application/dto/response/CreatePlanResponse.java
+++ b/src/main/java/com/pravell/plan/application/dto/response/CreatePlanResponse.java
@@ -1,5 +1,6 @@
 package com.pravell.plan.application.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -13,5 +14,7 @@ public class CreatePlanResponse {
     private String name;
     private Boolean isPublic;
     private LocalDateTime createdAt;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
 }

--- a/src/main/java/com/pravell/plan/application/dto/response/FindPlanResponse.java
+++ b/src/main/java/com/pravell/plan/application/dto/response/FindPlanResponse.java
@@ -2,6 +2,7 @@ package com.pravell.plan.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.pravell.plan.domain.model.Member;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -20,6 +21,8 @@ public class FindPlanResponse {
     private UUID ownerId;
     private String ownerNickname;
     private List<Member> member;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
 }
 

--- a/src/main/java/com/pravell/plan/application/dto/response/FindPlansResponse.java
+++ b/src/main/java/com/pravell/plan/application/dto/response/FindPlansResponse.java
@@ -1,6 +1,8 @@
 package com.pravell.plan.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +13,12 @@ public class FindPlansResponse {
 
     private UUID planId;
     private String planName;
+
     @JsonProperty("isOwner")
     private boolean isOwner;
+
+    private List<String> members;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
 }

--- a/src/main/java/com/pravell/plan/domain/model/Plan.java
+++ b/src/main/java/com/pravell/plan/domain/model/Plan.java
@@ -76,6 +76,22 @@ public class Plan extends AggregateRoot {
         this.name = name;
     }
 
+    public void updateStartDate(LocalDate startDate) {
+        validateDate(startDate, this.endDate);
+        this.startDate = startDate;
+    }
+
+    public void updateEndDate(LocalDate endDate) {
+        validateDate(this.startDate, endDate);
+        this.endDate = endDate;
+    }
+
+    public void updateDate(LocalDate startDate, LocalDate endDate) {
+        validateDate(startDate, endDate);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
     private static void validateName(String name) {
         if (name == null || name.length() < 2 || name.length() > 20) {
             throw new IllegalArgumentException("플랜 이름은 2 ~ 20자 사이여야 합니다.");
@@ -87,5 +103,4 @@ public class Plan extends AggregateRoot {
             throw new IllegalArgumentException("종료 날짜가 시작 날짜보다 앞설 수 없습니다.");
         }
     }
-
 }

--- a/src/main/java/com/pravell/plan/domain/model/Plan.java
+++ b/src/main/java/com/pravell/plan/domain/model/Plan.java
@@ -34,7 +34,10 @@ public class Plan extends AggregateRoot {
     @Column(nullable = false)
     private Boolean isDeleted;
 
+    @Column(nullable = false)
     private LocalDate startDate;
+
+    @Column(nullable = false)
     private LocalDate endDate;
 
     @Override

--- a/src/main/java/com/pravell/plan/domain/model/Plan.java
+++ b/src/main/java/com/pravell/plan/domain/model/Plan.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,18 +34,8 @@ public class Plan extends AggregateRoot {
     @Column(nullable = false)
     private Boolean isDeleted;
 
-    public static Plan create(String name, Boolean isPublic) {
-        return Plan.builder()
-                .id(UUID.randomUUID())
-                .name(name)
-                .isPublic(isPublic)
-                .isDeleted(false)
-                .build();
-    }
-
-    public void delete() {
-        isDeleted = true;
-    }
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     @Override
     public String toString() {
@@ -56,6 +47,24 @@ public class Plan extends AggregateRoot {
                 '}';
     }
 
+    public static Plan create(String name, Boolean isPublic, LocalDate startDate, LocalDate endDate) {
+        validateName(name);
+        validateDate(startDate, endDate);
+
+        return Plan.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .isPublic(isPublic)
+                .isDeleted(false)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+
+    public void delete() {
+        isDeleted = true;
+    }
+
     public void updatePublic(Boolean isPublic) {
         this.isPublic = isPublic;
     }
@@ -63,4 +72,17 @@ public class Plan extends AggregateRoot {
     public void updateName(String name) {
         this.name = name;
     }
+
+    private static void validateName(String name) {
+        if (name == null || name.length() < 2 || name.length() > 20) {
+            throw new IllegalArgumentException("플랜 이름은 2 ~ 20자 사이여야 합니다.");
+        }
+    }
+
+    private static void validateDate(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("종료 날짜가 시작 날짜보다 앞설 수 없습니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/pravell/plan/domain/service/PlanAuthorizationService.java
+++ b/src/main/java/com/pravell/plan/domain/service/PlanAuthorizationService.java
@@ -1,0 +1,31 @@
+package com.pravell.plan.domain.service;
+
+import com.pravell.plan.domain.model.PlanUserStatus;
+import com.pravell.plan.domain.model.PlanUsers;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlanAuthorizationService {
+
+    public boolean isOwnerOrMember(UUID userId, List<PlanUsers> planUsers) {
+        return planUsers.stream()
+                .anyMatch(pm ->
+                        pm.getUserId().equals(userId) &&
+                                (pm.getPlanUserStatus() == PlanUserStatus.OWNER ||
+                                        pm.getPlanUserStatus() == PlanUserStatus.MEMBER));
+    }
+
+    public boolean hasPublicPlanPermission(UUID userId, List<PlanUsers> planUsers) {
+        return planUsers.stream()
+                .noneMatch(pm ->
+                        pm.getUserId().equals(userId) && pm.getPlanUserStatus().equals(PlanUserStatus.BLOCKED));
+    }
+
+    public boolean isOwner(UUID userId, List<PlanUsers> planUsers) {
+        return planUsers.stream()
+                .anyMatch(pu -> pu.getUserId().equals(userId) && pu.getPlanUserStatus().equals(PlanUserStatus.OWNER));
+    }
+
+}

--- a/src/main/java/com/pravell/plan/domain/service/PlanCreateService.java
+++ b/src/main/java/com/pravell/plan/domain/service/PlanCreateService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 public class PlanCreateService {
 
     public PlanCreatedEvent create(CreatePlanApplicationRequest request, UUID id){
-        Plan plan = Plan.create(request.getName(), request.getIsPublic());
+        Plan plan = Plan.create(request.getName(), request.getIsPublic(), request.getStartDate(), request.getEndDate());
         PlanUsers planUsers = PlanUsers.createOwnerForPlan(id, plan.getId());
 
         return new PlanCreatedEvent(plan, planUsers, LocalDateTime.now());

--- a/src/main/java/com/pravell/plan/presentation/PlanController.java
+++ b/src/main/java/com/pravell/plan/presentation/PlanController.java
@@ -41,9 +41,8 @@ public class PlanController {
     }
 
     @GetMapping
-    public ResponseEntity<List<FindPlansResponse>> findPlans(
-            @RequestHeader("Authorization") String authorizationHeader) {
-        UUID id = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+    public ResponseEntity<List<FindPlansResponse>> findPlans(@RequestHeader("Authorization") String header) {
+        UUID id = commonJwtUtil.getUserIdFromToken(header);
         return ResponseEntity.ok(planFacade.findAllPlans(id));
     }
 

--- a/src/main/java/com/pravell/plan/presentation/request/CreatePlanRequest.java
+++ b/src/main/java/com/pravell/plan/presentation/request/CreatePlanRequest.java
@@ -4,6 +4,7 @@ import com.pravell.plan.application.dto.request.CreatePlanApplicationRequest;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,10 +19,18 @@ public class CreatePlanRequest {
     @NotNull(message = "공개 여부를 지정해야 합니다.")
     private Boolean isPublic;
 
+    @NotNull(message = "여행 시작일은 생략이 불가능합니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "여행 종료일은 생략이 불가능합니다.")
+    private LocalDate endDate;
+
     public CreatePlanApplicationRequest toApplicationRequest(){
         return CreatePlanApplicationRequest.builder()
                 .name(this.name)
                 .isPublic(this.isPublic)
+                .startDate(this.startDate)
+                .endDate(this.endDate)
                 .build();
     }
 

--- a/src/main/java/com/pravell/plan/presentation/request/UpdatePlanRequest.java
+++ b/src/main/java/com/pravell/plan/presentation/request/UpdatePlanRequest.java
@@ -2,6 +2,7 @@ package com.pravell.plan.presentation.request;
 
 import com.pravell.plan.application.dto.request.UpdatePlanApplicationRequest;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,11 +14,15 @@ public class UpdatePlanRequest {
     private String name;
 
     private Boolean isPublic;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     public UpdatePlanApplicationRequest toApplicationRequest(){
         return UpdatePlanApplicationRequest.builder()
                 .name(this.name)
                 .isPublic(this.isPublic)
+                .startDate(this.startDate)
+                .endDate(this.endDate)
                 .build();
     }
 

--- a/src/test/java/com/pravell/marker/presentation/MarkerControllerTestSupport.java
+++ b/src/test/java/com/pravell/marker/presentation/MarkerControllerTestSupport.java
@@ -11,6 +11,7 @@ import com.pravell.plan.domain.repository.PlanUsersRepository;
 import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -48,6 +49,8 @@ public abstract class MarkerControllerTestSupport extends ControllerTestSupport 
                 .name("name")
                 .isDeleted(isDeleted)
                 .isPublic(isPublic)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .build();
     }
 

--- a/src/test/java/com/pravell/place/presentation/PlaceControllerFindAllTest.java
+++ b/src/test/java/com/pravell/place/presentation/PlaceControllerFindAllTest.java
@@ -14,6 +14,7 @@ import com.pravell.plan.domain.model.PlanUsers;
 import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -27,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.StringUtils;
 
 class PlaceControllerFindAllTest extends PlaceControllerTestSupport {
 
@@ -54,12 +56,12 @@ class PlaceControllerFindAllTest extends PlaceControllerTestSupport {
         PlanUsers planUsers = getPlanUsers(plan.getId(), user.getId(), planUserStatus);
         planUsersRepository.save(planUsers);
 
-        PinPlace pinPlace1 = getPinPlace(plan.getId());
-        PinPlace pinPlace2 = getPinPlace(plan.getId());
-        PinPlace pinPlace3 = getPinPlace(plan.getId());
+        PinPlace pinPlace1 = getPinPlace("add1", plan.getId());
+        PinPlace pinPlace2 = getPinPlace("add2", plan.getId());
+        PinPlace pinPlace3 = getPinPlace("add3", plan.getId());
 
-        PinPlace pinPlace4 = getPinPlace(plan2.getId());
-        PinPlace pinPlace5 = getPinPlace(plan2.getId());
+        PinPlace pinPlace4 = getPinPlace("add4", plan2.getId());
+        PinPlace pinPlace5 = getPinPlace("add5", plan2.getId());
         pinPlaceRepository.saveAll(List.of(pinPlace1, pinPlace2, pinPlace3, pinPlace4, pinPlace5));
 
         String token = buildToken(user.getId(), "access", issuer, Instant.now().plusSeconds(10000));
@@ -78,11 +80,16 @@ class PlaceControllerFindAllTest extends PlaceControllerTestSupport {
 
         //then
         assertThat(responseList).hasSize(3)
-                .extracting("title", "mapx", "mapy", "pinColor")
+                .extracting("title", "mapx", "mapy", "pinColor", "address", "roadAddress", "hours")
                 .containsExactlyInAnyOrder(
-                        tuple(pinPlace1.getTitle(), pinPlace1.getMapx(), pinPlace1.getMapy(), pinPlace1.getPinColor()),
-                        tuple(pinPlace2.getTitle(), pinPlace2.getMapx(), pinPlace2.getMapy(), pinPlace2.getPinColor()),
-                        tuple(pinPlace3.getTitle(), pinPlace3.getMapx(), pinPlace3.getMapy(), pinPlace3.getPinColor())
+                        tuple(pinPlace1.getTitle(), pinPlace1.getMapx(), pinPlace1.getMapy(), pinPlace1.getPinColor(),
+                                pinPlace1.getAddress(), pinPlace1.getRoadAddress(), parseHours(pinPlace1.getHours())),
+
+                        tuple(pinPlace2.getTitle(), pinPlace2.getMapx(), pinPlace2.getMapy(), pinPlace2.getPinColor(),
+                                pinPlace2.getAddress(), pinPlace2.getRoadAddress(), parseHours(pinPlace2.getHours())),
+
+                        tuple(pinPlace3.getTitle(), pinPlace3.getMapx(), pinPlace3.getMapy(), pinPlace3.getPinColor(),
+                                pinPlace3.getAddress(), pinPlace3.getRoadAddress(), parseHours(pinPlace3.getHours()))
                 );
     }
 
@@ -181,11 +188,16 @@ class PlaceControllerFindAllTest extends PlaceControllerTestSupport {
 
         //then
         assertThat(responseList).hasSize(3)
-                .extracting("title", "mapx", "mapy", "pinColor")
+                .extracting("title", "mapx", "mapy", "pinColor", "address", "roadAddress", "hours")
                 .containsExactlyInAnyOrder(
-                        tuple(pinPlace1.getTitle(), pinPlace1.getMapx(), pinPlace1.getMapy(), pinPlace1.getPinColor()),
-                        tuple(pinPlace2.getTitle(), pinPlace2.getMapx(), pinPlace2.getMapy(), pinPlace2.getPinColor()),
-                        tuple(pinPlace3.getTitle(), pinPlace3.getMapx(), pinPlace3.getMapy(), pinPlace3.getPinColor())
+                        tuple(pinPlace1.getTitle(), pinPlace1.getMapx(), pinPlace1.getMapy(), pinPlace1.getPinColor(),
+                                pinPlace1.getAddress(), pinPlace1.getRoadAddress(), parseHours(pinPlace1.getHours())),
+
+                        tuple(pinPlace2.getTitle(), pinPlace2.getMapx(), pinPlace2.getMapy(), pinPlace2.getPinColor(),
+                                pinPlace2.getAddress(), pinPlace2.getRoadAddress(), parseHours(pinPlace2.getHours())),
+
+                        tuple(pinPlace3.getTitle(), pinPlace3.getMapx(), pinPlace3.getMapy(), pinPlace3.getPinColor(),
+                                pinPlace3.getAddress(), pinPlace3.getRoadAddress(), parseHours(pinPlace3.getHours()))
                 );
     }
 
@@ -337,6 +349,19 @@ class PlaceControllerFindAllTest extends PlaceControllerTestSupport {
                 Arguments.of("정지된 유저", UserStatus.SUSPENDED),
                 Arguments.of("차단된 유저", UserStatus.BLOCKED)
         );
+    }
+
+    private List<String> parseHours(String hours) throws Exception {
+        List<String> hoursList = new ArrayList<>();
+
+        if (StringUtils.hasText(hours) && !hours.equals("정보 없음")) {
+            hoursList = objectMapper.readValue(hours, new TypeReference<>() {
+            });
+        } else {
+            hoursList.add("정보 없음");
+        }
+
+        return hoursList;
     }
 
 }

--- a/src/test/java/com/pravell/place/presentation/PlaceControllerTestSupport.java
+++ b/src/test/java/com/pravell/place/presentation/PlaceControllerTestSupport.java
@@ -12,6 +12,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,8 @@ public abstract class PlaceControllerTestSupport extends ControllerTestSupport {
                 .name("name")
                 .isDeleted(isDeleted)
                 .isPublic(isPublic)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .build();
     }
 

--- a/src/test/java/com/pravell/plan/application/DeletePlanServiceTest.java
+++ b/src/test/java/com/pravell/plan/application/DeletePlanServiceTest.java
@@ -7,6 +7,7 @@ import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
+import com.pravell.plan.domain.service.PlanAuthorizationService;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 class DeletePlanServiceTest {
 
-    private final DeletePlanService deletePlanService = new DeletePlanService();
+    private final DeletePlanService deletePlanService = new DeletePlanService(new PlanAuthorizationService());
 
     private final UUID ownerId = UUID.randomUUID();
     private final UUID memberId = UUID.randomUUID();

--- a/src/test/java/com/pravell/plan/application/FindPlanServiceTest.java
+++ b/src/test/java/com/pravell/plan/application/FindPlanServiceTest.java
@@ -7,12 +7,16 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import com.pravell.common.exception.AccessDeniedException;
 import com.pravell.plan.application.dto.response.FindPlansResponse;
+import com.pravell.plan.domain.model.Member;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
 import com.pravell.plan.domain.repository.PlanRepository;
 import com.pravell.plan.domain.repository.PlanUsersRepository;
+import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -71,8 +75,14 @@ class FindPlanServiceTest {
         planUsersRepository.saveAll(
                 List.of(planUsers1, planUsers2, planUsers3, planUsers4, planUsers5, planUsers6, planUsers7));
 
+        Map<UUID, List<Member>> planIdAndPlanMembers = new HashMap<>();
+
+        planIdAndPlanMembers.put(plan1.getId(), List.of(getMember("멤버 1"), getMember("멤버 2")));
+        planIdAndPlanMembers.put(plan2.getId(), List.of(getMember("멤버1")));
+        planIdAndPlanMembers.put(plan3.getId(), List.of(getMember("멤버4"), getMember("멤버5")));
+
         //when
-        List<FindPlansResponse> responses = findPlanService.findAll(userId);
+        List<FindPlansResponse> responses = findPlanService.findAll(userId, planIdAndPlanMembers);
 
         //then
         assertThat(responses).hasSize(3)
@@ -157,6 +167,8 @@ class FindPlanServiceTest {
                 .name(name)
                 .isPublic(isPublic)
                 .isDeleted(isDeleted)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .build();
     }
 
@@ -173,6 +185,8 @@ class FindPlanServiceTest {
                 .id(planId)
                 .name("테스트 여행")
                 .isDeleted(false)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .isPublic(isPublic)
                 .build();
     }
@@ -182,6 +196,13 @@ class FindPlanServiceTest {
                 .planId(planId)
                 .userId(userId)
                 .planUserStatus(status)
+                .build();
+    }
+
+    private Member getMember(String nickname) {
+        return Member.builder()
+                .memberId(UUID.randomUUID())
+                .nickname(nickname)
                 .build();
     }
 

--- a/src/test/java/com/pravell/plan/application/UpdatePlanServiceTest.java
+++ b/src/test/java/com/pravell/plan/application/UpdatePlanServiceTest.java
@@ -8,6 +8,7 @@ import com.pravell.plan.application.dto.request.UpdatePlanApplicationRequest;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanUserStatus;
 import com.pravell.plan.domain.model.PlanUsers;
+import com.pravell.plan.domain.service.PlanAuthorizationService;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,7 @@ class UpdatePlanServiceTest {
 
     @BeforeEach
     void setUp() {
-        updatePlanService = new UpdatePlanService();
+        updatePlanService = new UpdatePlanService(new PlanAuthorizationService());
         ownerId = UUID.randomUUID();
         memberId = UUID.randomUUID();
         plan = Plan.builder()

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerCreateTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerCreateTest.java
@@ -8,7 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.jayway.jsonpath.JsonPath;
 import com.pravell.ControllerTestSupport;
+import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.repository.PlanRepository;
 import com.pravell.plan.domain.repository.PlanUsersRepository;
 import com.pravell.plan.presentation.request.CreatePlanRequest;
@@ -16,14 +18,21 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
 
 @DisplayName("플랜 생성 통합테스트")
 class PlanControllerCreateTest extends ControllerTestSupport {
@@ -66,7 +75,7 @@ class PlanControllerCreateTest extends ControllerTestSupport {
         String token = buildToken(userId, "access", issuer, Instant.now().plusSeconds(30000));
 
         //when, then
-        mockMvc.perform(
+        MvcResult mvcResult = mockMvc.perform(
                         post("/api/v1/plans")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(request))
@@ -76,7 +85,18 @@ class PlanControllerCreateTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.planId").isNotEmpty())
                 .andExpect(jsonPath("$.name").value(request.getName()))
                 .andExpect(jsonPath("$.isPublic").value(request.getIsPublic()))
-                .andExpect(jsonPath("$.createdAt").isNotEmpty());
+                .andExpect(jsonPath("$.createdAt").isNotEmpty())
+                .andExpect(jsonPath("$.startDate").value(request.getStartDate().toString()))
+                .andExpect(jsonPath("$.endDate").value(request.getEndDate().toString()))
+                .andReturn();
+
+        String contentAsString = mvcResult.getResponse().getContentAsString();
+        UUID planId = UUID.fromString(JsonPath.read(contentAsString, "$.planId"));
+
+        Optional<Plan> plan = planRepository.findById(planId);
+        assertThat(plan).isPresent();
+        assertThat(plan.get().getName()).isEqualTo(request.getName());
+        assertThat(plan.get().getStartDate()).isEqualTo(request.getStartDate());
     }
 
     @DisplayName("유저가 존재하지 않으면 여행 플랜 생성에 실패하고, 404를 반환한다.")
@@ -167,7 +187,6 @@ class PlanControllerCreateTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.code").value("Bad Request"))
                 .andExpect(jsonPath("$.message").value("name: 플랜 이름은 생략이 불가능합니다."));
 
-
         assertThat(planRepository.count()).isZero();
         assertThat(planUsersRepository.count()).isZero();
     }
@@ -221,6 +240,52 @@ class PlanControllerCreateTest extends ControllerTestSupport {
         assertThat(planUsersRepository.count()).isZero();
     }
 
+    @DisplayName("여행 시작일이 Null이면 플랜 생성에 실패하고, 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenStartDateIsNull() throws Exception {
+        //given
+        CreatePlanRequest request = getCreatePlanRequest("플랜1", true, null, LocalDate.parse("2025-09-30"));
+
+        String token = buildToken(userId, "access", issuer, Instant.now().plusSeconds(30000));
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/v1/plans")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("startDate: 여행 시작일은 생략이 불가능합니다."));
+
+        assertThat(planRepository.count()).isZero();
+        assertThat(planUsersRepository.count()).isZero();
+    }
+
+    @DisplayName("여행 종료일이 Null이면 플랜 생성에 실패하고, 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenEndDateIsNull() throws Exception {
+        //given
+        CreatePlanRequest request = getCreatePlanRequest("플랜1", true, LocalDate.parse("2025-09-30"), null);
+
+        String token = buildToken(userId, "access", issuer, Instant.now().plusSeconds(30000));
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/v1/plans")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("endDate: 여행 종료일은 생략이 불가능합니다."));
+
+        assertThat(planRepository.count()).isZero();
+        assertThat(planUsersRepository.count()).isZero();
+    }
+
     @DisplayName("accessToken이 만료되었으면 플랜 생성에 실패하고, 401을 반환한다.")
     @Test
     void shouldReturnUnauthorized_whenAccessTokenExpired() throws Exception {
@@ -263,16 +328,17 @@ class PlanControllerCreateTest extends ControllerTestSupport {
                 .andReturn();
     }
 
-    @DisplayName("이미 탈퇴한 유저는 플랜 생성에 실패하고, 404를 반환한다.")
-    @Test
-    void shouldReturnNotFound_whenUserHasWithdrawn() throws Exception {
+    @DisplayName("이미 탈퇴, 삭제, 정지, 차단된 유저는 플랜 생성에 실패하고, 404를 반환한다.")
+    @ParameterizedTest(name = "[{index}] 상태 : {0}")
+    @MethodSource("inactiveUserStates")
+    void shouldReturn404_whenUserIsInactive(String role, UserStatus userStatus) throws Exception {
         //given
         User user = User.builder()
                 .id(UUID.randomUUID())
                 .userId("userId")
                 .password("passwordd")
                 .nickname("nickname")
-                .status(UserStatus.WITHDRAWN)
+                .status(userStatus)
                 .build();
         userRepository.save(user);
 
@@ -293,101 +359,50 @@ class PlanControllerCreateTest extends ControllerTestSupport {
                 .andReturn();
     }
 
-    @DisplayName("이미 삭제된 유저는 플랜 생성에 실패하고, 404를 반환한다.")
-    @Test
-    void shouldReturnNotFound_whenUserHasDeleted() throws Exception {
-        //given
-        User user = User.builder()
-                .id(UUID.randomUUID())
-                .userId("userId")
-                .password("passwordd")
-                .nickname("nickname")
-                .status(UserStatus.DELETED)
-                .build();
-        userRepository.save(user);
+    private static Stream<Arguments> inactiveUserStates() {
+        return Stream.of(
+                Arguments.of("탈퇴한 유저", UserStatus.WITHDRAWN),
+                Arguments.of("삭제된 유저", UserStatus.DELETED),
+                Arguments.of("정지된 유저", UserStatus.SUSPENDED),
+                Arguments.of("차단된 유저", UserStatus.BLOCKED)
+        );
+    }
 
-        String token = buildToken(user.getId(), "access", issuer, Instant.now().plusSeconds(100000));
-        CreatePlanRequest request = getCreatePlanRequest("플랜1", true);
+    @DisplayName("종료일이 시작일보다 앞서면 플랜 생성에 실패하고, 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenEndDateIsBeforeStartDate() throws Exception {
+        //given
+        CreatePlanRequest request = getCreatePlanRequest("경주 여행", true, LocalDate.parse("2025-09-30"), LocalDate.parse("2025-09-01"));
+
+        String token = buildToken(userId, "access", issuer, Instant.now().plusSeconds(30000));
 
         //when, then
         mockMvc.perform(
                         post("/api/v1/plans")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("Not Found"))
-                .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다."))
-                .andReturn();
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("종료 날짜가 시작 날짜보다 앞설 수 없습니다."));
+
+        assertThat(planRepository.count()).isZero();
+        assertThat(planUsersRepository.count()).isZero();
     }
 
-    @DisplayName("이미 정지된 유저는 플랜 생성에 실패하고, 404를 반환한다.")
-    @Test
-    void shouldReturnNotFound_whenUserHasSuspended() throws Exception {
-        //given
-        User user = User.builder()
-                .id(UUID.randomUUID())
-                .userId("userId")
-                .password("passwordd")
-                .nickname("nickname")
-                .status(UserStatus.SUSPENDED)
-                .build();
-        userRepository.save(user);
-
-        String token = buildToken(user.getId(), "access", issuer, Instant.now().plusSeconds(100000));
-        CreatePlanRequest request = getCreatePlanRequest("플랜1", true);
-
-        //when, then
-        mockMvc.perform(
-                        post("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("Not Found"))
-                .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다."))
-                .andReturn();
-    }
-
-    @DisplayName("이미 차단된 유저는 플랜 생성에 실패하고, 404를 반환한다.")
-    @Test
-    void shouldReturnNotFound_whenUserHasBlocked() throws Exception {
-        //given
-        User user = User.builder()
-                .id(UUID.randomUUID())
-                .userId("userId")
-                .password("passwordd")
-                .nickname("nickname")
-                .status(UserStatus.BLOCKED)
-                .build();
-        userRepository.save(user);
-
-        String token = buildToken(user.getId(), "access", issuer, Instant.now().plusSeconds(100000));
-        CreatePlanRequest request = getCreatePlanRequest("플랜1", true);
-
-        //when, then
-        mockMvc.perform(
-                        post("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("Not Found"))
-                .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다."))
-                .andReturn();
-    }
-
-    private static CreatePlanRequest getCreatePlanRequest(String planName, Boolean isPublic) {
+    private static CreatePlanRequest getCreatePlanRequest(String planName, Boolean isPublic, LocalDate startDate,
+                                                          LocalDate endDate) {
         return CreatePlanRequest.builder()
                 .name(planName)
                 .isPublic(isPublic)
+                .startDate(startDate)
+                .endDate(endDate)
                 .build();
+    }
+
+    private static CreatePlanRequest getCreatePlanRequest(String planName, Boolean isPublic) {
+        return getCreatePlanRequest(planName, isPublic, LocalDate.parse("2025-09-29"), LocalDate.parse("2025-09-30"));
     }
 
 }

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerDeleteTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerDeleteTest.java
@@ -15,6 +15,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -61,6 +62,8 @@ class PlanControllerDeleteTest extends ControllerTestSupport {
             .name("경주 여행")
             .isDeleted(false)
             .isPublic(true)
+            .startDate(LocalDate.parse("2025-09-29"))
+            .endDate(LocalDate.parse("2025-09-30"))
             .build();
 
 
@@ -82,6 +85,8 @@ class PlanControllerDeleteTest extends ControllerTestSupport {
             .name("경주 여행")
             .isDeleted(false)
             .isPublic(false)
+            .startDate(LocalDate.parse("2025-09-29"))
+            .endDate(LocalDate.parse("2025-09-30"))
             .build();
 
 
@@ -295,6 +300,8 @@ class PlanControllerDeleteTest extends ControllerTestSupport {
                 .id(UUID.randomUUID())
                 .isDeleted(true)
                 .isPublic(true)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .name("플랜1")
                 .build();
         planRepository.save(deletedPlan);

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerFindAllTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerFindAllTest.java
@@ -1,12 +1,13 @@
 package com.pravell.plan.presentation;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.pravell.ControllerTestSupport;
 import com.pravell.plan.domain.model.Plan;
 import com.pravell.plan.domain.model.PlanUserStatus;
@@ -17,8 +18,13 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,55 +55,104 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
     @Test
     void shouldRetrieveAllActivePlansUserParticipatesIn() throws Exception {
         //given
-        UUID userId = UUID.randomUUID();
+        User user1 = getUser("유저 1", UserStatus.ACTIVE);
+        User user2 = getUser("유저 2", UserStatus.ACTIVE);
+        User user3 = getUser("유저 3", UserStatus.BLOCKED);
+        User user4 = getUser("유저 4", UserStatus.ACTIVE);
+        User user5 = getUser("유저 5", UserStatus.WITHDRAWN);
+        userRepository.saveAll(List.of(user1, user2, user3, user4, user5));
 
-        userRepository.save(User.builder()
-                .id(userId)
-                .userId("userId")
-                .password("passwordd")
-                .nickname("nickname")
-                .status(UserStatus.ACTIVE)
-                .build());
+        Plan plan1 = getPlan("정상 조회 플랜1", true, false, LocalDate.parse("2025-09-20"), LocalDate.parse("2025-09-29"));
+        PlanUsers planUsers1 = getPlanUsers(PlanUserStatus.OWNER, plan1.getId(), user1.getId());
+        PlanUsers planUsers2 = getPlanUsers(PlanUserStatus.MEMBER, plan1.getId(), user2.getId());
+        PlanUsers planUsers3 = getPlanUsers(PlanUserStatus.MEMBER, plan1.getId(), user3.getId());
 
-        Plan plan1 = getPlan("정상 조회 플랜1", true, false);
-        PlanUsers planUsers1 = getPlanUsers(PlanUserStatus.OWNER, plan1.getId(), userId);
-        Plan plan2 = getPlan("정상 조회 플랜2", false, false);
-        PlanUsers planUsers2 = getPlanUsers(PlanUserStatus.OWNER, plan2.getId(), userId);
-        Plan plan3 = getPlan("정상 조회 플랜3", true, false);
-        PlanUsers planUsers3 = getPlanUsers(PlanUserStatus.MEMBER, plan3.getId(), userId);
+        Plan plan2 = getPlan("정상 조회 플랜2", false, false, LocalDate.parse("2025-10-10"), LocalDate.parse("2025-11-10"));
+        PlanUsers planUsers4 = getPlanUsers(PlanUserStatus.OWNER, plan2.getId(), user2.getId());
+        PlanUsers planUsers5 = getPlanUsers(PlanUserStatus.MEMBER, plan2.getId(), user4.getId());
+        PlanUsers planUsers6 = getPlanUsers(PlanUserStatus.MEMBER, plan2.getId(), user5.getId());
+        PlanUsers planUsers14 = getPlanUsers(PlanUserStatus.MEMBER, plan2.getId(), user1.getId());
 
-        Plan plan4 = getPlan("삭제된 플랜1", true, true);
-        PlanUsers planUsers4 = getPlanUsers(PlanUserStatus.MEMBER, plan4.getId(), userId);
-        Plan plan5 = getPlan("탈퇴한 플랜1", true, false);
-        PlanUsers planUsers5 = getPlanUsers(PlanUserStatus.WITHDRAWN, plan5.getId(), userId);
-        Plan plan6 = getPlan("강퇴당한 플랜1", true, false);
-        PlanUsers planUsers6 = getPlanUsers(PlanUserStatus.KICKED, plan6.getId(), userId);
-        Plan plan7 = getPlan("차단당한 플랜1", true, false);
-        PlanUsers planUsers7 = getPlanUsers(PlanUserStatus.KICKED, plan7.getId(), userId);
+        Plan plan3 = getPlan("정상 조회 플랜3", true, false, LocalDate.parse("2025-12-20"), LocalDate.parse("2025-12-29"));
+        PlanUsers planUsers7 = getPlanUsers(PlanUserStatus.OWNER, plan3.getId(), user2.getId());
+        PlanUsers planUsers8 = getPlanUsers(PlanUserStatus.MEMBER, plan3.getId(), user1.getId());
+        PlanUsers planUsers9 = getPlanUsers(PlanUserStatus.MEMBER, plan3.getId(), user5.getId());
 
-        planRepository.saveAll(List.of(plan1, plan2, plan3, plan4, plan5, plan6, plan7));
+        Plan plan4 = getPlan("유저가 속하지 않은 플랜1", true, false, LocalDate.parse("2025-12-20"),
+                LocalDate.parse("2025-12-29"));
+        PlanUsers planUsers15 = getPlanUsers(PlanUserStatus.OWNER, plan4.getId(), user2.getId());
+        PlanUsers planUsers16 = getPlanUsers(PlanUserStatus.MEMBER, plan4.getId(), user5.getId());
+        Plan plan5 = getPlan("삭제된 플랜1", true, true, LocalDate.parse("2025-12-20"), LocalDate.parse("2025-12-29"));
+        PlanUsers planUsers10 = getPlanUsers(PlanUserStatus.MEMBER, plan5.getId(), user1.getId());
+        Plan plan6 = getPlan("탈퇴한 플랜1", true, false);
+        PlanUsers planUsers11 = getPlanUsers(PlanUserStatus.WITHDRAWN, plan6.getId(), user1.getId());
+        Plan plan7 = getPlan("강퇴당한 플랜1", true, false);
+        PlanUsers planUsers12 = getPlanUsers(PlanUserStatus.KICKED, plan7.getId(), user1.getId());
+        Plan plan8 = getPlan("차단당한 플랜1", true, false);
+        PlanUsers planUsers13 = getPlanUsers(PlanUserStatus.KICKED, plan8.getId(), user1.getId());
+
+        planRepository.saveAll(List.of(plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8));
         planUsersRepository.saveAll(
-                List.of(planUsers1, planUsers2, planUsers3, planUsers4, planUsers5, planUsers6, planUsers7));
+                List.of(planUsers1, planUsers2, planUsers3, planUsers4, planUsers5, planUsers6, planUsers7, planUsers8,
+                        planUsers9, planUsers10, planUsers11, planUsers12, planUsers13, planUsers14, planUsers15,
+                        planUsers16));
 
-        String token = buildToken(userId, "access", issuer, Instant.now().plusSeconds(10000));
+        String token = buildToken(user1.getId(), "access", issuer, Instant.now().plusSeconds(10000));
 
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(3)))
-                .andExpect(jsonPath("$[*].planId", containsInAnyOrder(
-                        plan1.getId().toString(),
-                        plan2.getId().toString(),
-                        plan3.getId().toString())))
-                .andExpect(jsonPath("$[*].planName", containsInAnyOrder(
-                        plan1.getName(),
-                        plan2.getName(),
-                        plan3.getName())))
-                .andExpect(jsonPath("$[*].isOwner", containsInAnyOrder(true, true, false)));
+                .andDo(result -> {
+                    List<Map<String, Object>> response = objectMapper.readValue(
+                            result.getResponse().getContentAsString(),
+                            new TypeReference<>() {}
+                    );
+
+                    List<Tuple> actual = response.stream()
+                            .map(map -> tuple(
+                                    UUID.fromString((String) map.get("planId")),
+                                    map.get("planName"),
+                                    map.get("isOwner"),
+                                    LocalDate.parse((String) map.get("startDate")),
+                                    LocalDate.parse((String) map.get("endDate")),
+                                    ((List<?>) map.get("members")).stream()
+                                            .map(Object::toString)
+                                            .sorted()
+                                            .collect(Collectors.toList())
+                            ))
+                            .collect(Collectors.toList());
+
+                    assertThat(actual).containsExactlyInAnyOrder(
+                            tuple(
+                                    plan1.getId(),
+                                    plan1.getName(),
+                                    true,
+                                    plan1.getStartDate(),
+                                    plan1.getEndDate(),
+                                    Stream.of(user1.getNickname(), user2.getNickname()).sorted().toList()
+                            ),
+                            tuple(
+                                    plan2.getId(),
+                                    plan2.getName(),
+                                    false,
+                                    plan2.getStartDate(),
+                                    plan2.getEndDate(),
+                                    Stream.of(user1.getNickname(), user2.getNickname(), user4.getNickname()).sorted().toList()
+                            ),
+                            tuple(
+                                    plan3.getId(),
+                                    plan3.getName(),
+                                    false,
+                                    plan3.getStartDate(),
+                                    plan3.getEndDate(),
+                                    Stream.of(user1.getNickname(), user2.getNickname()).sorted().toList()
+                            )
+                    );
+                });
     }
 
     @DisplayName("로그인 한 유저가 존재하지 않으면 404를 반환한다.")
@@ -109,7 +164,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("Not Found"))
@@ -134,9 +189,9 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
 
         //when, then
         mockMvc.perform(
-                get("/api/v1/plans")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get("/api/v1/plans")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("Not Found"))
                 .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다."));
@@ -161,7 +216,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("Not Found"))
@@ -187,7 +242,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("Not Found"))
@@ -213,7 +268,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("Not Found"))
@@ -239,7 +294,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("Unauthorized"))
@@ -265,7 +320,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("Unauthorized"))
@@ -291,7 +346,7 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
         //when, then
         mockMvc.perform(
                         get("/api/v1/plans")
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer "+token+"111")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token + "111")
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("Unauthorized"))
@@ -299,11 +354,17 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
     }
 
     private Plan getPlan(String name, boolean isPublic, boolean isDeleted) {
+        return getPlan(name, isPublic, isDeleted, LocalDate.parse("2025-09-29"), LocalDate.parse("2025-09-30"));
+    }
+
+    private Plan getPlan(String name, boolean isPublic, boolean isDeleted, LocalDate startDate, LocalDate endDate) {
         return Plan.builder()
                 .id(UUID.randomUUID())
                 .name(name)
                 .isPublic(isPublic)
                 .isDeleted(isDeleted)
+                .startDate(startDate)
+                .endDate(endDate)
                 .build();
     }
 
@@ -312,6 +373,16 @@ class PlanControllerFindAllTest extends ControllerTestSupport {
                 .planId(planId)
                 .userId(userId)
                 .planUserStatus(status)
+                .build();
+    }
+
+    private static User getUser(String nickname, UserStatus userStatus) {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .userId("userId" + UUID.randomUUID().toString())
+                .password("passwordd")
+                .nickname(nickname)
+                .status(userStatus)
                 .build();
     }
 

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
@@ -17,6 +17,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -536,6 +537,8 @@ class PlanControllerFindTest extends ControllerTestSupport {
                         .name(name)
                         .isPublic(isPublic)
                         .isDeleted(isDeleted)
+                        .startDate(LocalDate.parse("2025-09-29"))
+                        .endDate(LocalDate.parse("2025-09-30"))
                         .build()
         );
 

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
@@ -131,6 +131,8 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.isPublic").value("true"))
                 .andExpect(jsonPath("$.ownerId").value(owner.getId().toString()))
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
+                .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
+                .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -167,6 +169,8 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.isPublic").value("true"))
                 .andExpect(jsonPath("$.ownerId").value(owner.getId().toString()))
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
+                .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
+                .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -363,6 +367,8 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.isPublic").value("true"))
                 .andExpect(jsonPath("$.ownerId").value(owner.getId().toString()))
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
+                .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
+                .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -399,6 +405,8 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.isPublic").value("true"))
                 .andExpect(jsonPath("$.ownerId").value(owner.getId().toString()))
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
+                .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
+                .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerUpdateTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerUpdateTest.java
@@ -16,6 +16,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -69,6 +70,8 @@ class PlanControllerUpdateTest extends ControllerTestSupport {
             .name("경주 여행")
             .isDeleted(false)
             .isPublic(true)
+            .startDate(LocalDate.parse("2025-09-29"))
+            .endDate(LocalDate.parse("2025-09-30"))
             .build();
 
 
@@ -90,6 +93,8 @@ class PlanControllerUpdateTest extends ControllerTestSupport {
             .name("경주 여행")
             .isDeleted(false)
             .isPublic(false)
+            .startDate(LocalDate.parse("2025-09-29"))
+            .endDate(LocalDate.parse("2025-09-30"))
             .build();
 
 

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerUpdateTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerUpdateTest.java
@@ -159,6 +159,173 @@ class PlanControllerUpdateTest extends ControllerTestSupport {
         assertThat(afterPlan.get().getName()).isEqualTo(request.getName());
     }
 
+    @DisplayName("해당 플랜의 OWNER일 경우, 여행 시작 날짜 업데이트에 성공한다.")
+    @Test
+    void shouldUpdateStartDateSuccessfully_whenUserIsOwner() throws Exception {
+        //given
+        UpdatePlanRequest request = UpdatePlanRequest.builder()
+                .startDate(LocalDate.parse("2025-01-01"))
+                .build();
+
+        String token = buildToken(owner.getId(), "access", issuer, Instant.now().plusSeconds(10000));
+
+        Optional<Plan> beforePlan = planRepository.findById(publicPlan.getId());
+        assertThat(beforePlan).isPresent();
+        assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
+        assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+
+        //when, then
+        mockMvc.perform(
+                        patch("/api/v1/plans/" + publicPlan.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.planId").value(publicPlan.getId().toString()))
+                .andExpect(jsonPath("$.name").value(publicPlan.getName()))
+                .andExpect(jsonPath("$.isPublic").value(publicPlan.getIsPublic()))
+                .andExpect(jsonPath("$.startDate").value(request.getStartDate().toString()))
+                .andExpect(jsonPath("$.endDate").value(publicPlan.getEndDate().toString()))
+                .andExpect(jsonPath("$.createdAt").isNotEmpty());
+
+        Optional<Plan> afterPlan = planRepository.findById(publicPlan.getId());
+        assertThat(afterPlan).isPresent();
+        assertThat(afterPlan.get().getStartDate()).isNotEqualTo(publicPlan.getStartDate());
+        assertThat(afterPlan.get().getStartDate()).isEqualTo(request.getStartDate());
+    }
+
+    @DisplayName("해당 플랜의 OWNER일 경우, 여행 종료 날짜 업데이트에 성공한다.")
+    @Test
+    void shouldUpdateEndDateSuccessfully_whenUserIsOwner() throws Exception {
+        //given
+        UpdatePlanRequest request = UpdatePlanRequest.builder()
+                .endDate(LocalDate.parse("2025-12-10"))
+                .build();
+
+        String token = buildToken(owner.getId(), "access", issuer, Instant.now().plusSeconds(10000));
+
+        Optional<Plan> beforePlan = planRepository.findById(publicPlan.getId());
+        assertThat(beforePlan).isPresent();
+        assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
+        assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+
+        //when, then
+        mockMvc.perform(
+                        patch("/api/v1/plans/" + publicPlan.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.planId").value(publicPlan.getId().toString()))
+                .andExpect(jsonPath("$.name").value(publicPlan.getName()))
+                .andExpect(jsonPath("$.isPublic").value(publicPlan.getIsPublic()))
+                .andExpect(jsonPath("$.startDate").value(publicPlan.getStartDate().toString()))
+                .andExpect(jsonPath("$.endDate").value(request.getEndDate().toString()))
+                .andExpect(jsonPath("$.createdAt").isNotEmpty());
+
+        Optional<Plan> afterPlan = planRepository.findById(publicPlan.getId());
+        assertThat(afterPlan).isPresent();
+        assertThat(afterPlan.get().getEndDate()).isNotEqualTo(publicPlan.getEndDate());
+        assertThat(afterPlan.get().getEndDate()).isEqualTo(request.getEndDate());
+    }
+
+    @DisplayName("해당 플랜의 OWNER고 여행 종료 날짜가 시작 날짜보다 앞서도록 변경하면 변경에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenOwnerUpdatesPlanWithInvalidDateRange() throws Exception {
+        //given
+        UpdatePlanRequest request = UpdatePlanRequest.builder()
+                .startDate(LocalDate.parse("2025-01-01"))
+                .endDate(LocalDate.parse("2024-01-01"))
+                .build();
+
+        String token = buildToken(owner.getId(), "access", issuer, Instant.now().plusSeconds(10000));
+
+        Optional<Plan> beforePlan = planRepository.findById(publicPlan.getId());
+        assertThat(beforePlan).isPresent();
+        assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
+        assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+
+        //when, then
+        mockMvc.perform(
+                        patch("/api/v1/plans/" + publicPlan.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("종료 날짜가 시작 날짜보다 앞설 수 없습니다."));
+
+        Optional<Plan> afterPlan = planRepository.findById(publicPlan.getId());
+        assertThat(afterPlan).isPresent();
+        assertThat(afterPlan.get().getStartDate()).isEqualTo(publicPlan.getStartDate());
+        assertThat(afterPlan.get().getStartDate()).isNotEqualTo(request.getStartDate());
+        assertThat(afterPlan.get().getEndDate()).isEqualTo(publicPlan.getEndDate());
+        assertThat(afterPlan.get().getEndDate()).isNotEqualTo(request.getEndDate());
+    }
+
+    @DisplayName("해당 플랜의 OWNER고 여행 종료 날짜가 시작 날짜보다 앞서도록 변경하면 변경에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenOwnerUpdatesPlanWithInvalidDateRange2() throws Exception {
+        //given
+        UpdatePlanRequest request = UpdatePlanRequest.builder()
+                .startDate(LocalDate.parse("2026-01-01"))
+                .build();
+
+        String token = buildToken(owner.getId(), "access", issuer, Instant.now().plusSeconds(10000));
+
+        Optional<Plan> beforePlan = planRepository.findById(publicPlan.getId());
+        assertThat(beforePlan).isPresent();
+        assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
+        assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+
+        //when, then
+        mockMvc.perform(
+                        patch("/api/v1/plans/" + publicPlan.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("종료 날짜가 시작 날짜보다 앞설 수 없습니다."));
+
+        Optional<Plan> afterPlan = planRepository.findById(publicPlan.getId());
+        assertThat(afterPlan).isPresent();
+        assertThat(afterPlan.get().getStartDate()).isEqualTo(publicPlan.getStartDate());
+        assertThat(afterPlan.get().getStartDate()).isNotEqualTo(request.getStartDate());
+    }
+
+    @DisplayName("해당 플랜의 OWNER고 여행 종료 날짜가 시작 날짜보다 앞서도록 변경하면 변경에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenOwnerUpdatesPlanWithInvalidDateRange3() throws Exception {
+        //given
+        UpdatePlanRequest request = UpdatePlanRequest.builder()
+                .endDate(LocalDate.parse("2023-01-01"))
+                .build();
+
+        String token = buildToken(owner.getId(), "access", issuer, Instant.now().plusSeconds(10000));
+
+        Optional<Plan> beforePlan = planRepository.findById(publicPlan.getId());
+        assertThat(beforePlan).isPresent();
+        assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
+        assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+
+        //when, then
+        mockMvc.perform(
+                        patch("/api/v1/plans/" + publicPlan.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("종료 날짜가 시작 날짜보다 앞설 수 없습니다."));
+
+        Optional<Plan> afterPlan = planRepository.findById(publicPlan.getId());
+        assertThat(afterPlan).isPresent();
+        assertThat(afterPlan.get().getEndDate()).isEqualTo(publicPlan.getEndDate());
+        assertThat(afterPlan.get().getEndDate()).isNotEqualTo(request.getEndDate());
+    }
+
+
     @DisplayName("해당 플랜의 OWNER일 경우, 플랜 공개 여부 업데이트에 성공한다.")
     @Test
     void shouldUpdatePlanVisibilitySuccessfully_whenUserIsOwner() throws Exception {
@@ -327,6 +494,37 @@ class PlanControllerUpdateTest extends ControllerTestSupport {
         assertThat(beforePlan.get().getIsPublic()).isNotEqualTo(request.getIsPublic());
         assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
         assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+    }
+
+    @DisplayName("해당 플랜의 MEMBER일 경우, 여행 시작 날짜 업데이트에 실패하고, 403을 반환한다.")
+    @Test
+    void shouldThrowAccessDenied_whenMemberTriesToUpdateStartDate() throws Exception {
+        //given
+        UpdatePlanRequest request = UpdatePlanRequest.builder()
+                .startDate(LocalDate.parse("2025-01-01"))
+                .build();
+
+        String token = buildToken(member.getId(), "access", issuer, Instant.now().plusSeconds(10000));
+
+        Optional<Plan> beforePlan = planRepository.findById(publicPlan.getId());
+        assertThat(beforePlan).isPresent();
+        assertThat(beforePlan.get().getName()).isEqualTo(publicPlan.getName());
+        assertThat(beforePlan.get().getName()).isNotEqualTo(request.getName());
+
+        //when, then
+        mockMvc.perform(
+                        patch("/api/v1/plans/" + publicPlan.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("해당 리소스를 수정 할 권한이 없습니다."));
+
+        Optional<Plan> afterPlan = planRepository.findById(publicPlan.getId());
+        assertThat(afterPlan).isPresent();
+        assertThat(afterPlan.get().getStartDate()).isEqualTo(publicPlan.getStartDate());
+        assertThat(afterPlan.get().getStartDate()).isNotEqualTo(request.getStartDate());
     }
 
     @DisplayName("해당 플랜에 참여하지 않은 유저의 경우, 플랜 이름 업데이트에 실패하고, 403을 반환한다.")

--- a/src/test/java/com/pravell/plan/presentation/PlanMemberControllerCreateInviteCodeTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanMemberControllerCreateInviteCodeTest.java
@@ -22,6 +22,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -91,6 +92,8 @@ class PlanMemberControllerCreateInviteCodeTest extends ControllerTestSupport {
             .name("경주 여행")
             .isPublic(true)
             .isDeleted(false)
+            .startDate(LocalDate.parse("2025-09-29"))
+            .endDate(LocalDate.parse("2025-09-30"))
             .build();
 
     private final Plan deletedPlan = Plan.builder()
@@ -98,6 +101,8 @@ class PlanMemberControllerCreateInviteCodeTest extends ControllerTestSupport {
             .name("경주 여행")
             .isPublic(true)
             .isDeleted(true)
+            .startDate(LocalDate.parse("2025-09-29"))
+            .endDate(LocalDate.parse("2025-09-30"))
             .build();
 
     private final PlanUsers planUsers1 = PlanUsers.builder()

--- a/src/test/java/com/pravell/plan/presentation/PlanMemberControllerJoinTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanMemberControllerJoinTest.java
@@ -17,6 +17,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -606,6 +607,8 @@ class PlanMemberControllerJoinTest extends ControllerTestSupport {
                 .name("name" + UUID.randomUUID())
                 .isDeleted(idDeleted)
                 .isPublic(isPublic)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .build();
     }
 

--- a/src/test/java/com/pravell/plan/presentation/PlanMemberControllerKickedTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanMemberControllerKickedTest.java
@@ -16,6 +16,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -334,6 +335,8 @@ class PlanMemberControllerKickedTest extends ControllerTestSupport {
                 .name("경주여행")
                 .isPublic(true)
                 .isDeleted(isDeleted)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .build();
     }
 

--- a/src/test/java/com/pravell/plan/presentation/PlanMemberControllerWithdrawTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanMemberControllerWithdrawTest.java
@@ -16,6 +16,7 @@ import com.pravell.user.domain.model.User;
 import com.pravell.user.domain.model.UserStatus;
 import com.pravell.user.domain.repository.UserRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -522,6 +523,8 @@ class PlanMemberControllerWithdrawTest extends ControllerTestSupport {
                 .name("경주여행")
                 .isPublic(true)
                 .isDeleted(isDeleted)
+                .startDate(LocalDate.parse("2025-09-29"))
+                .endDate(LocalDate.parse("2025-09-30"))
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 

## 📝작업 내용

- plan startDate, endDate 추가
- 플랜 생성 : 여행 시작 날짜, 종료 날짜 추가로 받도록 변경
- 플랜 전체 조회 : 플랜에 참여중인 멤버 닉네임, 여행 시작 날짜, 종료 날짜 추가로 반환
- 플랜 상세 조회 : 여행 시작 날짜, 종료 날짜 추가로 반환
- 플랜 수정 : 여행 시작, 종료 날짜 추가로 수정할 수 있도록 변경

- 저장한 장소 전체 조회 : 주소, 도로명 주소, 영업시간 추가로 반환

- plan 권한 관리 도메인 서비스로 분리
