### PR TITLE
[Fix] #20 여행 플랜 조회

### DIFF
--- a/src/main/java/com/pravell/plan/application/PlanFacade.java
+++ b/src/main/java/com/pravell/plan/application/PlanFacade.java
@@ -97,6 +97,11 @@ public class PlanFacade {
 
     private FindPlanResponse buildFindPlanResponse(Plan plan, UUID ownerId,
                                                           Pair<String, List<Member>> ownerAndMembers, UUID userId) {
+        List<Member> members = ownerAndMembers.getSecond();
+        boolean isMember = members.stream()
+                .map(Member::getMemberId)
+                .anyMatch(userId::equals);
+
         return FindPlanResponse.builder()
                 .planId(plan.getId())
                 .name(plan.getName())
@@ -108,6 +113,7 @@ public class PlanFacade {
                 .startDate(plan.getStartDate())
                 .endDate(plan.getEndDate())
                 .isOwner(ownerId.equals(userId))
+                .isMember(isMember)
                 .build();
     }
 

--- a/src/main/java/com/pravell/plan/application/PlanFacade.java
+++ b/src/main/java/com/pravell/plan/application/PlanFacade.java
@@ -92,11 +92,11 @@ public class PlanFacade {
         UUID ownerId = extractOwnerId(planUsers);
         Pair<String, List<Member>> ownerAndMembers = separateOwnerAndMembers(ownerId, userMembers);
 
-        return buildFindPlanResponse(plan, ownerId, ownerAndMembers);
+        return buildFindPlanResponse(plan, ownerId, ownerAndMembers, userId);
     }
 
-    private static FindPlanResponse buildFindPlanResponse(Plan plan, UUID ownerId,
-                                                        Pair<String, List<Member>> ownerAndMembers) {
+    private FindPlanResponse buildFindPlanResponse(Plan plan, UUID ownerId,
+                                                          Pair<String, List<Member>> ownerAndMembers, UUID userId) {
         return FindPlanResponse.builder()
                 .planId(plan.getId())
                 .name(plan.getName())
@@ -107,6 +107,7 @@ public class PlanFacade {
                 .member(ownerAndMembers.getSecond())
                 .startDate(plan.getStartDate())
                 .endDate(plan.getEndDate())
+                .isOwner(ownerId.equals(userId))
                 .build();
     }
 
@@ -175,10 +176,10 @@ public class PlanFacade {
         return Pair.of(ownerNickname, members);
     }
 
-    private List<Member> getMembers(List<UUID> memberId){
+    private List<Member> getMembers(List<UUID> memberId) {
         List<UserMemberDTO> userMembers = userService.findMembers(memberId);
 
-        return userMembers.stream().map(um->{
+        return userMembers.stream().map(um -> {
             return Member.builder()
                     .nickname(um.getNickname())
                     .memberId(um.getMemberId())

--- a/src/main/java/com/pravell/plan/application/dto/response/FindPlanResponse.java
+++ b/src/main/java/com/pravell/plan/application/dto/response/FindPlanResponse.java
@@ -28,5 +28,8 @@ public class FindPlanResponse {
     @JsonProperty("isOwner")
     private boolean isOwner;
 
+    @JsonProperty("isMember")
+    private boolean isMember;
+
 }
 

--- a/src/main/java/com/pravell/plan/application/dto/response/FindPlanResponse.java
+++ b/src/main/java/com/pravell/plan/application/dto/response/FindPlanResponse.java
@@ -15,14 +15,18 @@ public class FindPlanResponse {
 
     private UUID planId;
     private String name;
-    @JsonProperty("isPublic")
-    private boolean isPublic;
     private LocalDateTime createdAt;
     private UUID ownerId;
     private String ownerNickname;
     private List<Member> member;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonProperty("isPublic")
+    private boolean isPublic;
+
+    @JsonProperty("isOwner")
+    private boolean isOwner;
 
 }
 

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
@@ -134,6 +134,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andExpect(jsonPath("$.isOwner").value(true))
+                .andExpect(jsonPath("$.isMember").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -173,6 +174,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andExpect(jsonPath("$.isOwner").value(false))
+                .andExpect(jsonPath("$.isMember").value(true))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -372,6 +374,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andExpect(jsonPath("$.isOwner").value(false))
+                .andExpect(jsonPath("$.isMember").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -411,6 +414,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
                 .andExpect(jsonPath("$.isOwner").value(false))
+                .andExpect(jsonPath("$.isMember").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -495,6 +499,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.ownerId").value(owner.getId().toString()))
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
                 .andExpect(jsonPath("$.isOwner").value(false))
+                .andExpect(jsonPath("$.isMember").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();

--- a/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
+++ b/src/test/java/com/pravell/plan/presentation/PlanControllerFindTest.java
@@ -133,6 +133,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
+                .andExpect(jsonPath("$.isOwner").value(true))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -171,6 +172,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
+                .andExpect(jsonPath("$.isOwner").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -369,6 +371,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
+                .andExpect(jsonPath("$.isOwner").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -407,6 +410,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
                 .andExpect(jsonPath("$.startDate").value(LocalDate.parse("2025-09-29").toString()))
                 .andExpect(jsonPath("$.endDate").value(LocalDate.parse("2025-09-30").toString()))
+                .andExpect(jsonPath("$.isOwner").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -490,6 +494,7 @@ class PlanControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.isPublic").value("true"))
                 .andExpect(jsonPath("$.ownerId").value(owner.getId().toString()))
                 .andExpect(jsonPath("$.ownerNickname").value(owner.getNickname()))
+                .andExpect(jsonPath("$.isOwner").value(false))
                 .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #20 

## 📝작업 내용

> 여행 플랜 상세 조회시 소유자, 멤버 여부 추가 반환하도록 수정
